### PR TITLE
Add building for MacOSX-arm64

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,6 @@
 provider:
   win: azure
 conda_forge_output_validation: true
+build_platform:
+  osx_arm64: osx_64
+test_on_native_only: true

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,6 +9,7 @@ cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
     -DMSGPACK_CXX11=YES \
+    ${CMAKE_ARGS} \
     ..
 
 ninja install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,4 +13,8 @@ cmake \
     ..
 
 ninja install
-ctest
+
+if [[ "$CONDA_BUILD_CROSS_COMPILATION" != "1" ]]; then
+  ctest
+fi
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - ambiguous_nan_inf.patch   # [linux]
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
I've attempted to follow the instructions at https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/#how-to-add-a-osx-arm64-build-to-a-feedstock about the steps required for doing this.

The build instructions work fine on my local machine, but I don't know how to test the cross-compilation locally.